### PR TITLE
Add GH workflow to automatically build and deploy Docker images + multiarch support (amd64/arm6/arm64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.github
+README.MD
+LICENSE

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,51 @@
+name: Docker image
+
+on:
+  # Run manually from the Actions tab
+  workflow_dispatch:
+  # Run automatically when a change is pushed on master
+  #push:
+  #  branches: master
+
+env:
+  PLATFORMS: linux/amd64,linux/arm/v6,linux/arm64
+  DOCKER_HUB_REPOSITORY: ${{ github.repository }}
+  DOCKER_HUB_TAG: latest
+
+jobs:
+  docker:
+    name: Docker build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU for multi-arch build
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.DOCKER_HUB_REPOSITORY }}:${{ env.DOCKER_HUB_TAG }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,16 +1,17 @@
 name: Docker image
 
 on:
-  # Run manually from the Actions tab
   workflow_dispatch:
-  # Run automatically when a change is pushed on master
-  #push:
-  #  branches: master
+    inputs:
+      docker_tag:
+        description: 'Docker image tag'
+        required: true
+        default: 'latest'
 
 env:
   PLATFORMS: linux/amd64,linux/arm/v6,linux/arm64
   DOCKER_HUB_REPOSITORY: ${{ github.repository }}
-  DOCKER_HUB_TAG: latest
+  DOCKER_HUB_TAG: ${{ github.event.inputs.docker_tag }}
 
 jobs:
   docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repos
     && apk update \
     && apk add --no-cache pkgconfig gammu=1.39.0-r2 gammu-libs=1.39.0-r2 gammu-dev=1.39.0-r2
 
+RUN python -m pip install -U pip
+
 # Build dependencies in a dedicated stage
 FROM base AS dependencies
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
-FROM python:3-alpine
+FROM python:3-alpine AS base
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories
-RUN apk update
-RUN apk add --no-cache pkgconfig gammu=1.39.0-r2 gammu-libs=1.39.0-r2  gammu-dev=1.39.0-r2
-RUN mkdir ssl
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories \
+    && apk update \
+    && apk add --no-cache pkgconfig gammu=1.39.0-r2 gammu-libs=1.39.0-r2 gammu-dev=1.39.0-r2
 
+# Build dependencies in a dedicated stage
+FROM base AS dependencies
+COPY requirements.txt .
+RUN apk add --no-cache --virtual .build-deps libffi-dev openssl-dev gcc musl-dev python3-dev cargo \
+    && pip install -r requirements.txt
+
+# Switch back to base layer for final stage
+FROM base AS final
 ENV BASE_PATH /sms-gw
-RUN mkdir $BASE_PATH
+RUN mkdir $BASE_PATH /ssl
 WORKDIR $BASE_PATH
-ADD requirements.txt .
-ADD gammu.config .
-ADD credentials.txt .
-ADD support.py .
+COPY . $BASE_PATH
 
-#RUN pip install -r requirements.txt
-
-RUN apk add --no-cache --virtual .build-deps libffi-dev openssl-dev gcc musl-dev \
-     && pip install -r requirements.txt \
-     && apk del .build-deps libffi-dev openssl-dev gcc musl-dev
-
-ADD run.py .
+COPY --from=dependencies /root/.cache /root/.cache
+RUN pip install -r requirements.txt && rm -rf /root/.cache
 
 CMD [ "python", "./run.py" ]


### PR DESCRIPTION
The primary goal of my changes was to build a Docker image for arm6 (Raspberry pi)

About the changes:
- I have added `python3-dev` and `cargo `dependencies in the `DockerFile` as required by https://cryptography.io/en/latest/installation.html#alpine
- I also have updated the `Dockerfile` to a multi-stage build to keep the images as small as possible
- I have added a `docker_image.yml` workflow to build and push the amd64/arm6/arm64 images automatically
  - You need to add 2 secrets in your project settings:
    - `DOCKER_HUB_USERNAME` = your Docker Hub username
    - `DOCKER_HUB_ACCESS_TOKEN` = your Docker Hub token
  - In Actions, you can then run the `Docker image` workflow (the first build takes ~20 minutes but intermediate layers are cached so the subsequent builds are faster)

The GH workflow is running fine on my [GitHub project](https://github.com/gpailler/sms-gammu-gateway/actions?query=workflow%3A%22Docker+image%22) and the images are properly pushed to my [Docker repository](https://hub.docker.com/r/gpailler/sms-gammu-gateway/tags?page=1&ordering=last_updated). I have tested the arm6 image on a RPi 2 and it's running fine. 

Thanks for your project!