### PR TITLE
Support multi-part and encoded SMS. Add endpoints to retrieve all SMS, retrieve/delete nth SMS, and retrieve network info

### DIFF
--- a/support.py
+++ b/support.py
@@ -24,3 +24,51 @@ def init_state_machine(pin, filename='gammu.config'):
         else:
             sm.EnterSecurityCode('PIN', pin)
     return sm
+
+
+def retrieveAllSms(machine):
+    status = machine.GetSMSStatus()
+    allMultiPartSmsCount = status['SIMUsed'] + status['PhoneUsed'] + status['TemplatesUsed']
+
+    allMultiPartSms = []
+    start = True
+
+    while len(allMultiPartSms) < allMultiPartSmsCount:
+        if start:
+            currentMultiPartSms = machine.GetNextSMS(Start = True, Folder = 0)
+            start = False
+        else:
+            currentMultiPartSms = machine.GetNextSMS(Location = currentMultiPartSms[0]['Location'], Folder = 0)
+        allMultiPartSms.append(currentMultiPartSms)
+
+    allSms = gammu.LinkSMS(allMultiPartSms)
+
+    results = []
+    for sms in allSms:
+        smsPart = sms[0]
+
+        result = {
+            "Date": str(smsPart['DateTime']),
+            "Number": smsPart['Number'],
+            "State": smsPart['State'],
+            "Locations": [smsPart['Location'] for smsPart in sms],
+        }
+
+        decodedSms = gammu.DecodeSMS(sms)
+        if decodedSms == None:
+            result["Text"] = smsPart['Text']
+        else:
+            text = ""
+            for entry in decodedSms['Entries']:
+                if entry['Buffer'] != None:
+                    text += entry['Buffer']
+
+            result["Text"] = text
+
+        results.append(result)
+
+    return results
+
+
+def deleteSms(machine, sms):
+    list(map(lambda location: machine.DeleteSMS(Folder=0, Location=location), sms["Locations"]))


### PR DESCRIPTION
Global improvements to support multi-part SMS with encoding

- Support multi-part SMS
- Support encoded SMS (should handle diacritics properly)
- Add new API endpoints:
  - retrieve all SMS
  - retrieve nth SMS
  - delete nth SMS
  - retrieve network info
- Update README.md:
  - document new API endpoints 
  - update HomeAssistant section and add an automation sample to send a notification when a message is received

A docker image is available for testing [gpailler/sms-gammu-gateway:multipart-sms](https://hub.docker.com/layers/gpailler/sms-gammu-gateway/multipart-sms/images/sha256-1cff7353fcec8655aa19bb9351449d102ebac5bfe416b11d8052bd9d62315dd2?context=repo)