### PR TITLE
Fix and drop gammu version pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3-alpine AS base
 
-RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/community' >> /etc/apk/repositories \
-    && apk update \
-    && apk add --no-cache pkgconfig gammu=1.39.0-r2 gammu-libs=1.39.0-r2 gammu-dev=1.39.0-r2
+RUN ALPINE_VERSION=$(grep '^VERSION_ID=' /etc/os-release | sed -E 's/^.*=([0-9]+)\.([0-9]+)\..*/\1.\2/') && \
+	echo "http://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/community" >> /etc/apk/repositories \
+	&& apk update \
+	&& apk add --no-cache pkgconfig gammu gammu-libs gammu-dev
 
 RUN python -m pip install -U pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache --virtual .build-deps libffi-dev openssl-dev gcc musl-dev
 
 # Switch back to base layer for final stage
 FROM base AS final
-ENV BASE_PATH /sms-gw
+ENV BASE_PATH=/sms-gw
 RUN mkdir $BASE_PATH /ssl
 WORKDIR $BASE_PATH
 COPY . $BASE_PATH


### PR DESCRIPTION
Thank you for your great project! It is much appreciated :)

However, the current docker hub image is quite dated, and automatic scanners report a bunch of serios/critical security issues:

```
$ docker scout quickview pajikos/sms-gammu-gateway:latest
    i New version 1.18.4 available (installed version is 1.18.3) at https://github.com/docker/scout-cli
    ✓ SBOM of image already cached, 99 packages indexed

    i Base image was auto-detected. To get more accurate results, build images with max-mode provenance attestations.
      Review docs.docker.com ↗ for more information.

  Target               │  pajikos/sms-gammu-gateway:latest  │    6C    30H    56M     9L     1?
    digest             │  35306fd3bf99                      │
  Base image           │  python:3-alpine                   │    4C    10H    21M     0L
  Refreshed base image │  python:3-alpine                   │    0C     0H     1M     2L
                       │                                    │    -4    -10    -20     +2
  Updated base image   │  python:3-alpine3.21               │    0C     0H     1M     2L
                       │                                    │    -4    -10    -20     +2
```

This pull request drops the hard pinnings for alpine and gammu versions, and would alllow regular automatic builds.

In my fork, I am using the following "on" setting in the github action:

```
  # Automatic build every three months
  schedule:
    - cron: '0 6 1 1,4,7,10 *'
```
