### PR TITLE
Add option to limit listening to restricted ip addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ If only cdrom device appeared, install [usb-modeswitch](http://www.draisberghof.
 apt-get install usb-modeswitch
 ```
 
+Per default, sms-gammu-gateway will listen on all interfaces and IPv4
+addresses (or, more precisely, on 0.0.0.0). You can listen on local
+(or other sets of) addresses only by setting the BINDHOST environment
+variable, e.g. either using appropriate docker settings, or in/from the
+executing shell.
+
 ## Standalone installation
 This guide does not cover Python 3.x installation process (including pip), but it is required as well.
 #### Install system dependencies (using apt):

--- a/run.py
+++ b/run.py
@@ -10,6 +10,7 @@ from gammu import GSMNetworks
 pin = os.getenv('PIN', None)
 ssl = os.getenv('SSL', False)
 port = os.getenv('PORT', '5000')
+host = os.getenv('BINDHOST', '0.0.0.0')
 user_data = load_user_data()
 machine = init_state_machine(pin)
 app = Flask(__name__)
@@ -139,6 +140,6 @@ api.add_resource(Reset, '/reset', resource_class_args=[machine])
 
 if __name__ == '__main__':
     if ssl:
-        app.run(port=port, host="0.0.0.0", ssl_context=('/ssl/cert.pem', '/ssl/key.pem'))
+        app.run(port=port, host=host, ssl_context=('/ssl/cert.pem', '/ssl/key.pem'))
     else:
-        app.run(port=port, host="0.0.0.0")
+        app.run(port=port, host=host)


### PR DESCRIPTION
Add environment variable BINDHOST to listen on. The default remains 0.0.0.0, but the new variable allows restricting access to e.g. localhost.