### PR TITLE
Make modem tty configurable in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY . $BASE_PATH
 COPY --from=dependencies /root/.cache /root/.cache
 RUN pip install -r requirements.txt && rm -rf /root/.cache
 
-CMD [ "python", "./run.py" ]
+CMD [ "./docker_init.sh" ]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ services:
       - /dev/ttyUSB1:/dev/mobile
 ```
 
+You can switch the device name used for gammu communication by setting the
+"MODEM" environment variable, e.g., by using an "-e" argument in docker,
+or using an "environment" entry in docker-compose.yml.
+
 ## FAQ
 #### PIN configuration
 Pin to unblock SIM card could be set using environment variable PIN, e.g. PIN=1234.

--- a/docker_init.sh
+++ b/docker_init.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if  [ ! -z "$MODEM" ] ; then
+	echo "Updating gammu device to ${MODEM} ..."
+	sed -E "s#^(device\s+=\s*).*#\1${MODEM}#" gammu.config
+	echo "Done."
+fi
+
+exec python run.py


### PR DESCRIPTION
By setting the "MODEM" env variable, users can now use a differnt dev file.